### PR TITLE
feat: Nazwa w KRS nie może być zmieniona

### DIFF
--- a/tests/test_krs_validation.py
+++ b/tests/test_krs_validation.py
@@ -60,7 +60,7 @@ class TestRealKRSClient:
         client = RealKRSClient()
         is_valid, message = client.validate_krs(krs, expected_name)
 
-        assert is_valid
+        assert not is_valid
         assert "Niezgodność nazwy organizacji" in message
         assert "Wrong Foundation" in message
         assert "Correct Foundation" in message

--- a/validators.py
+++ b/validators.py
@@ -42,7 +42,7 @@ class RealKRSClient:
 
                 if yaml_name.lower() != krs_name.lower():
                     return (
-                        True,
+                        False,
                         f"Niezgodność nazwy organizacji: w YAML jest '{yaml_name}', ale w KRS jest '{krs_name}'",
                     )
 
@@ -95,7 +95,7 @@ class OrganizationSchemaValidator:
                 errors.append(f"Nieprawidłowy format KRS: {krs} (oczekiwano 10 cyfr)")
             else:
                 # Validate KRS against external API, including name match
-                org_name = data.get("nazwa")
+                org_name = data.get("nazwa_w_krs")
                 is_valid, error_msg = self.krs_client.validate_krs(krs, org_name)
                 if not is_valid:
                     errors.append(f"Walidacja KRS nie powiodła się: {error_msg}")


### PR DESCRIPTION
- nazwa dostępna w rejestrze KRS nie może być inna w YAML
- polem z nazwą w YAML jest teraz nazwa_w_krs
- pole z nazwą organizacji w YAML może być teraz dowolne
- brak poprawnej nazwy skutkuje nieudanym testem w CI